### PR TITLE
removes the forcemap on boxstation (unfucks map rotation)

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\boxstation.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"


### PR DESCRIPTION

## Description
the boxstation forcemap was checked in the DME, meaning that the second map couldnt be selected
## Changelog
:cl:
fix:map rotation actually rotates
/:cl: